### PR TITLE
Added options bar on the side and changed conversation page colors to a mixture of black and gray

### DIFF
--- a/public/sass/messaging.scss
+++ b/public/sass/messaging.scss
@@ -8,6 +8,12 @@
 	padding: 6rem;
 	padding-top: 4.5rem;
 	position: relative;
+
+	#return-home {
+		position: absolute;
+		color: $main;
+	}
+
 	h1 {
 		margin: auto;
 		margin-bottom: 0.5rem;
@@ -17,7 +23,6 @@
 		padding-top: 1.5rem;
 		font-family: $sans-stack;
 		font-weight: 700;
-		color: $light-main;
 		font-size: 2.2rem;
 		&:before {
 			content:"Topic of Today";
@@ -38,6 +43,24 @@
 
 	@media screen and (max-width: $max-display) {
 	  	padding: 1rem;
+	}
+}
+
+.optionsTitle {
+	margin: 0;
+	font-family: $sans-stack;
+	font-weight: 700;
+}
+
+.options {
+	list-style-type: none;
+	margin-top: 0;
+	padding-left: 0;
+	position: absolute;
+
+	li a {
+		font-family: $sans-stack;
+		color: $main;
 	}
 }
 

--- a/public/stylesheets/messaging.css
+++ b/public/stylesheets/messaging.css
@@ -6,7 +6,12 @@
   padding-top: 4.5rem;
   position: relative;
 }
-/* line 11, ../sass/messaging.scss */
+/* line 12, ../sass/messaging.scss */
+.wrapper #return-home {
+  position: absolute;
+  color: #777777;
+}
+/* line 17, ../sass/messaging.scss */
 .wrapper h1 {
   margin: auto;
   margin-bottom: 0.5rem;
@@ -16,10 +21,9 @@
   padding-top: 1.5rem;
   font-family: "Lato", "Lucidia Grande", serif;
   font-weight: 700;
-  color: #b0b0b0;
   font-size: 2.2rem;
 }
-/* line 22, ../sass/messaging.scss */
+/* line 27, ../sass/messaging.scss */
 .wrapper h1:before {
   content: "Topic of Today";
   position: absolute;
@@ -29,7 +33,7 @@
   font-size: 1.1rem;
 }
 @media screen and (max-width: 750px) {
-  /* line 11, ../sass/messaging.scss */
+  /* line 17, ../sass/messaging.scss */
   .wrapper h1 {
     margin-bottom: 1rem;
     font-size: 1.4rem;
@@ -48,7 +52,27 @@
   }
 }
 
-/* line 44, ../sass/messaging.scss */
+/* line 49, ../sass/messaging.scss */
+.optionsTitle {
+  margin: 0;
+  font-family: "Lato", "Lucidia Grande", serif;
+  font-weight: 700;
+}
+
+/* line 55, ../sass/messaging.scss */
+.options {
+  list-style-type: none;
+  margin-top: 0;
+  padding-left: 0;
+  position: absolute;
+}
+/* line 61, ../sass/messaging.scss */
+.options li a {
+  font-family: "Lato", "Lucidia Grande", serif;
+  color: #777777;
+}
+
+/* line 67, ../sass/messaging.scss */
 .display {
   margin: 0 auto;
   padding: 0.7rem 0;
@@ -59,40 +83,40 @@
   overflow-y: scroll;
 }
 @media screen and (max-width: 750px) {
-  /* line 44, ../sass/messaging.scss */
+  /* line 67, ../sass/messaging.scss */
   .display {
     padding-bottom: 10px;
   }
 }
 @media screen and (max-height: 750px) {
-  /* line 44, ../sass/messaging.scss */
+  /* line 67, ../sass/messaging.scss */
   .display {
     height: 180px;
   }
 }
 
-/* line 60, ../sass/messaging.scss */
+/* line 83, ../sass/messaging.scss */
 .display-area {
   color: #383838;
   font-weight: 400;
   font-size: 1rem;
 }
-/* line 64, ../sass/messaging.scss */
+/* line 87, ../sass/messaging.scss */
 .display-area p, .display-area br {
   margin: 0;
 }
-/* line 67, ../sass/messaging.scss */
+/* line 90, ../sass/messaging.scss */
 .display-area p {
   line-height: 1.45rem;
 }
 @media screen and (max-width: 750px) {
-  /* line 67, ../sass/messaging.scss */
+  /* line 90, ../sass/messaging.scss */
   .display-area p {
     font-size: 1.2rem;
   }
 }
 
-/* line 76, ../sass/messaging.scss */
+/* line 99, ../sass/messaging.scss */
 .display-fade, .display-fade-bottom {
   position: absolute;
   height: 1.8rem;
@@ -104,7 +128,7 @@
   background-image: linear-gradient(#ffffff, rgba(255, 255, 255, 0));
 }
 
-/* line 83, ../sass/messaging.scss */
+/* line 106, ../sass/messaging.scss */
 .display-fade-bottom {
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, rgba(255, 255, 255, 0)), color-stop(100%, #ffffff));
   background-image: -webkit-linear-gradient(rgba(255, 255, 255, 0), #ffffff);
@@ -114,7 +138,7 @@
   margin-top: -50px;
 }
 
-/* line 89, ../sass/messaging.scss */
+/* line 112, ../sass/messaging.scss */
 .input-area {
   margin: 0 auto;
   margin-top: 2rem;
@@ -124,11 +148,11 @@
   color: #383838;
   font-size: 1.1rem;
 }
-/* line 97, ../sass/messaging.scss */
+/* line 120, ../sass/messaging.scss */
 .input-area form {
   width: 100%;
 }
-/* line 99, ../sass/messaging.scss */
+/* line 122, ../sass/messaging.scss */
 .input-area form textarea {
   width: 100%;
   border: none;
@@ -137,19 +161,19 @@
   box-sizing: border-box;
 }
 @media screen and (max-width: 750px) {
-  /* line 99, ../sass/messaging.scss */
+  /* line 122, ../sass/messaging.scss */
   .input-area form textarea {
     height: 90px;
     padding: 0;
   }
 }
-/* line 110, ../sass/messaging.scss */
+/* line 133, ../sass/messaging.scss */
 .input-area form input {
   display: block;
   margin-top: 1rem;
   float: right;
 }
-/* line 115, ../sass/messaging.scss */
+/* line 138, ../sass/messaging.scss */
 .input-area form input[type="submit"] {
   background-color: #b0b0b0;
   border: none;
@@ -163,7 +187,7 @@
   box-shadow: rgba(128, 128, 128, 0.7) 0 4px 0 0, rgba(128, 128, 128, 0.2) -2px -1px 0 0 inset, rgba(128, 128, 128, 0.1) 2px -1px 0 0 inset, rgba(255, 255, 255, 0.5) 0 2px 0 0 inset;
   transition: all 0.3s ease;
 }
-/* line 131, ../sass/messaging.scss */
+/* line 154, ../sass/messaging.scss */
 .input-area form input[type="submit"]:hover {
   background-color: #555555;
   -webkit-box-shadow: rgba(0, 0, 0, 0.6) 0 4px 0 0, rgba(128, 128, 128, 0.9) -2px -1px 0 0 inset, rgba(128, 128, 128, 0.6) 2px -1px 0 0 inset, rgba(255, 255, 255, 0.45) 0 2px 0 0 inset;
@@ -171,7 +195,7 @@
   box-shadow: rgba(0, 0, 0, 0.6) 0 4px 0 0, rgba(128, 128, 128, 0.9) -2px -1px 0 0 inset, rgba(128, 128, 128, 0.6) 2px -1px 0 0 inset, rgba(255, 255, 255, 0.45) 0 2px 0 0 inset;
 }
 @media screen and (max-width: 750px) {
-  /* line 89, ../sass/messaging.scss */
+  /* line 112, ../sass/messaging.scss */
   .input-area {
     margin-top: 0;
   }

--- a/views/conversation.html
+++ b/views/conversation.html
@@ -27,6 +27,14 @@
 		</div>
 
 		<div class="display-fade"></div>
+		<span>
+			<h2 class="optionsTitle">Options</h2>
+			<ul class="options">
+				<li><a href ="/home">Invite others</a></li>
+				<li><a href="/home">Archive conversation</a></li>
+				<li><a href ="/home">Leave conversation</a></li>
+			</ul>
+		</span>
 		<div class="display">
 			<div class="display-area"></div>
 		</div>


### PR DESCRIPTION
I've added an options bar to the side to allow users to invite others, archive the conversation, and leave the conversation. I also altered the styling of the return to home option and made some color changes. We can change those later.

Here's a picture of what it looks like:
![options bar](https://cloud.githubusercontent.com/assets/5490475/3715139/6be8ca96-15d1-11e4-9651-383f422623d3.png)
