### PR TITLE
Add delete button to conversation page

### DIFF
--- a/views/conversation.html
+++ b/views/conversation.html
@@ -33,6 +33,7 @@
 				<li><a href ="/home">Invite others</a></li>
 				<li><a href="/home">Archive conversation</a></li>
 				<li><a href ="/home">Leave conversation</a></li>
+				<li><a href ="/home">Delete conversation</a></li>
 			</ul>
 		</span>
 		<div class="display">


### PR DESCRIPTION
Right now, we only have three options on the conversations option bar: invite others, archive conversation, and leave conversation. We should also include functionality to delete the conversation, and this PR takes care of including the button the frontend. This will complement Erik's work on deleting the conversation in the backend.

We can decide later who actually has the right to delete the conversation (the icebreaker, everyone in the group, etc.). For now, we're just focusing on having the functionality to do so.
