### PR TITLE
Home: People invite UI fix

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -13,21 +13,18 @@ function peopleTypeEvent () {
 			console.log(namesTemplate, data.message, namesTemplate(data))
 			$('#search_names').html(namesTemplate(data));
 
-			 // creating var to see if new names duplicate existing ones
-
+			// Check if any user included in the search results has already been selected for this conversation. If so, do not display this user's name in the search results.
 			$('.selected-name').each(function(){
 				var selectedName = $(this).attr('data-id');
-
 				$('.modal-name').each(function(){
 					var newName	= $(this).attr('data-id');
-					if(selectedName === newName){
+					if (selectedName === newName){
 						$('.modal-name[data-id="'+newName+'"]').remove();
 					}
 				});
-			}); // click on each new name
-
-		} // if data success
-	}); // get data
+			}); 
+		} 
+	}); 
 }
 $('#people_input').keyup(_.debounce(peopleTypeEvent, 400));
 

--- a/public/sass/home.scss
+++ b/public/sass/home.scss
@@ -280,7 +280,6 @@ html,body {
 			// position: absolute;
 		}
 		.selected-name {
-			
 			background-color: $light-gray;
 			padding: 5px;
 			margin-right: 5px;

--- a/public/stylesheets/home.css
+++ b/public/stylesheets/home.css
@@ -316,7 +316,7 @@ html, body {
   display: inline-block;
   border-radius: 3px;
 }
-/* line 292, ../sass/home.scss */
+/* line 291, ../sass/home.scss */
 #new-input-modal .people-select .selected-name .name_remove {
   position: absolute;
   top: 10px;
@@ -326,7 +326,7 @@ html, body {
   font-size: 0.5em;
   cursor: pointer;
 }
-/* line 303, ../sass/home.scss */
+/* line 302, ../sass/home.scss */
 #new-input-modal button {
   float: right;
   background-color: #b0b0b0;
@@ -341,7 +341,7 @@ html, body {
   box-shadow: rgba(128, 128, 128, 0.7) 0 4px 0 0, rgba(128, 128, 128, 0.2) -2px 0px 0 0 inset, rgba(128, 128, 128, 0.1) 2px 0px 0 0 inset, rgba(255, 255, 255, 0.5) 0 2px 0 0 inset;
   transition: all 0.3s ease;
 }
-/* line 320, ../sass/home.scss */
+/* line 319, ../sass/home.scss */
 #new-input-modal button:hover {
   background-color: #555555;
   -webkit-box-shadow: rgba(0, 0, 0, 0.7) 0 4px 0 0, rgba(128, 128, 128, 0.9) -2px 0px 0 0 inset, rgba(128, 128, 128, 0.6) 2px 0px 0 0 inset, rgba(255, 255, 255, 0.35) 0 2px 0 0 inset;

--- a/views/home.html
+++ b/views/home.html
@@ -50,11 +50,6 @@
 		<section class="home-contacts right-side">
 			<h2>Contacts</h2>
 			<div class="contacts-content">
-		<!-- 		<span class="name1 name">Nikil Selvam</span>
-				<span class="name2 name">Erik Luo</span>
-				<span class="name3 name">Tony Jing</span>
-				<span class="name4 name">Fifi Yeung</span>
-				<span class="name5 name">Sarah J.</span> -->
 
 			</div>
 		</section >
@@ -83,7 +78,7 @@
 			   <textarea name="content" rows="3" cols="20" placeholder="Write down your thoughts"></textarea>
 			</div>
 			<div class="btn-fld">
-			  <button type="submit">Create</button>
+			  <button id="create-submit-button" type="button">Create</button>
 			</div>
 		</form>
 	</div>
@@ -106,33 +101,36 @@
 				$('textarea').val('').attr('placeholder', 'Write down your thoughts');
 			});
 
+			var numOfNames;
+
 			$('#search_names').on('click', '.modal-name', function(){
 				var name = $(this).text();
 				var id = $(this).attr('data-id');
 				
 				$('<li  style="display: none;" data-id="' + id + '" class="selected-name">' + name + '<div class="name_remove">X</div></li>').appendTo($('.names-list')).fadeIn('fast');
 				$('#search_names li').remove();
-				if($('.names-list li').length == 1){
-					$('#people_input').css({
-						display: 'none'
-					}).slideDown('fast');
+				if ($('.names-list li').length === 1){
+					$('#people_input').hide().slideDown('fast');
 				}
 				$('#people_input').val('').attr('placeholder', 'Add More').focus();
-
-				$('.name_remove').click(function(){
-					$(this).parent().remove();
-				});
 
 				$('.modal_close').click(function(){
 					$('.names-list li').remove();
 				});
-				var numOfNames = $('li.selected-name').length;
-				if(numOfNames >= 5){
-					$('#people_input').attr('placeholder', "To keep the conversation close and meaningful, you can invite up to 5 people.").css('font-size', '16px');
+
+				numOfNames = $('li.selected-name').length;
+				if (numOfNames >= 5){
+					$('#people_input').hide();
 					$('textarea').focus();
 				}
 			}); // search on click
-			
+		
+			$('#convo-creation-form').on('click', '.name_remove', function(){
+				$(this).parent().remove();
+				if (numOfNames >= 4){
+					$('#people_input').show().focus();
+				}
+ 			});
 		}); // ready
 	</script>
 </body>


### PR DESCRIPTION
This branch fixes two issues:
It used to be that there were no limits on the number of people an user can invite. After this fix, the user be limited to inviting to up to 5 people. She/he will see the message "To keep the conversation close and meaningful, you can invite up to 5 people." displayed as the place holder text for the search box.
Question for @psybuzz, are users added based on the data-id that's in the DOM? I'm thinking of a senario when an user adds a person, but then removes the user from the selected list, is the person still added to the convo?

The second issue is that duplicate names are displayed when the user search for people. When a user selected a name, say 'Charles X', as one of the invitees, a subsequent search for 'Charles' will still show 'Charles X' in the dropdown of names. This push fixes that. Now the name is removed from the search results.
