### PR TITLE
Fix user color when submitting new message

### DIFF
--- a/public/js/Application.js
+++ b/public/js/Application.js
@@ -86,7 +86,6 @@ function styleNewNames (styleSelection){
             if (originalNameText === storedName){
                 colorValue = $currentName.find('.name-colors').css('background-color');
             }
-            console.log("akdjaa;d" +originalNameText+ "aklds;fja");
         });
 
         var initials = $currentShape.text()
@@ -151,8 +150,8 @@ $('#mainform').on('submit', function (e){
     // the user uses newlines in their post (such as when creating lists or when creating spacing between
     // multiple paragraph).
     var message = $('textarea').val();
-    message = message.replace(/(?:\r\n|\r|\n)/g, '<br />');
-    
+    message = message.replace(/(?:\r\n|\r|\n)/g, '\n');
+
 	function onSubmitError (err){
 		alert('Send failed.');
 	}


### PR DESCRIPTION
Right now, when the user submits a new message in an ongoing conversation, the user color circle is not showing. The reason is that the user color value is not created due to the user name string having an extra space at the end. This causes the user string to be not matched up with the user string in the list of users, where the original colors are stored. 

I couldn't figure out why the extra space is added to `$currentShape.text()` on line 80, but I did managed to fix the problem by using the `$.trim` function to remove the extra space.

Update: for the `<br />` tags creating the line breaks, for some reason they are not being recognized as proper html. So I've opted to use `\n` to make the change happen.
