### PR TITLE
Self exclusion when searching for users

### DIFF
--- a/routes/user.js
+++ b/routes/user.js
@@ -43,6 +43,10 @@ exports.search = function(req, res){
 	User.find({ username: new RegExp('^'+req.query.query, 'i')}, fields, function(err, docs, count){
 		if (err){ console.log(err) };
 
+		// Exclude the user's self from the search.
+		docs = docs.filter(function (e){
+			return e.username !== req.user.username;
+		});
 
 		User.find({ firstName: new RegExp('^'+req.query.query, 'i')}, fields, function(err2, docs2, count){
 			if (err2){ console.log(err2) };

--- a/routes/user.js
+++ b/routes/user.js
@@ -43,18 +43,20 @@ exports.search = function(req, res){
 	User.find({ username: new RegExp('^'+req.query.query, 'i')}, fields, function(err, docs, count){
 		if (err){ console.log(err) };
 
-		// Exclude the user's self from the search.
-		docs = docs.filter(function (e){
-			return e.username !== req.user.username;
-		});
-
 		User.find({ firstName: new RegExp('^'+req.query.query, 'i')}, fields, function(err2, docs2, count){
 			if (err2){ console.log(err2) };
 
 			User.find({ lastName: new RegExp('^'+req.query.query, 'i')}, fields, function(err3, docs3, count){
 				if (err3){ console.log(err3) };
 
+				// Combine results and exclude the user's self from the search.
 				var result = Utils.union(docs, docs2, docs3);
+				if (req.user && req.user.username){
+					result = result.filter(function (e){
+						return e.username !== req.user.username;
+					});
+				}
+
 				res.send({status: 'OK', success: true, message: result});
 			});
 		});


### PR DESCRIPTION
Currently, searching for other users (e.g., when creating a convo), is a global search across all users in the database.  This PR addresses a minor bug where searching for other users also includes oneself.  These commits excludes oneself from the results.