### PR TITLE
Unescape string on public pages

### DIFF
--- a/public/js/home.js
+++ b/public/js/home.js
@@ -82,8 +82,8 @@ $('#create-submit-button').click(function (){
 
 // Compile Handlebars template for conversation entries.
 var convoHtml = "<div class='convo'>\
-	<h3><a href='/conversation/{{id}}'>{{question}}</a></h3>\
-	{{#each participants}} <span data-id='{{_id}}' class='name'>{{firstName}} {{lastName}}</span> {{/each}}\
+	<h3><a href='/conversation/{{id}}'>{{{question}}}</a></h3>\
+	{{#each participants}} <span data-id='{{_id}}' class='name'>{{{firstName}}} {{{lastName}}}</span> {{/each}}\
 </div>";
 var convoTemplate = Handlebars.compile(convoHtml);
 

--- a/views/conversation.html
+++ b/views/conversation.html
@@ -21,10 +21,10 @@
 		<div class="menu-bar">
 			<a id="return-home" href="/home">&lt; all conversations</a>
 		</div>
-		<h1 id="question">{{title}}</h1>
+		<h1 id="question">{{{title}}}</h1>
 		<div id="participants">
 			{{#each participants}}
-				<span class='name'>{{firstName}} {{lastName}}</span>
+				<span class='name'>{{{firstName}}} {{{lastName}}}</span>
 			{{/each}}
 		</div>
 

--- a/views/error.html
+++ b/views/error.html
@@ -12,8 +12,8 @@
 	<link rel="stylesheet" type="text/css" href="/stylesheets/error.css">
 </head>
 <body>
-	<h1>{{title}}</h1>
-	<h3 style='color: gray'>{{message}}</h3>
+	<h1>{{{title}}}</h1>
+	<h3 style='color: gray'>{{{message}}}</h3>
 	<a href="..">Return to Home</a>
 </body>
 </html>

--- a/views/home.html
+++ b/views/home.html
@@ -19,7 +19,7 @@
 <body>
 	<div class="wrapper">
 		<section class="admin-bar">
-			<div class="personal-info">Welcome, <a href="#user-modal" id="user-profile" rel="leanModal">{{user.firstName}} {{user.lastName}}</a>!</div>
+			<div class="personal-info">Welcome, <a href="#user-modal" id="user-profile" rel="leanModal">{{{user.firstName}}} {{{user.lastName}}}</a>!</div>
 			<div id="log-out"><a href="/logout">Log Out</a></div>
 		</section>
 
@@ -83,23 +83,23 @@
 		<div class="modal_close">x</div>
 		<div id="name" class="info">
 			<span class="label">User:</span>
-			<span class="content">{{user.firstName}} {{user.lastName}}</span>
+			<span class="content">{{{user.firstName}}} {{{user.lastName}}}</span>
 		</div>
 		<div id="email" class="info">
 			<span class="label">Email:</span>
-			<span class="content">{{user.username}}</span>
+			<span class="content">{{{user.username}}}</span>
 		</div>
 		<div id="joined" class="info">
 			<span class="label">Joined:</span>
-			<span class="content">{{user.joined}}</span>
+			<span class="content">{{{user.joined}}}</span>
 		</div>
 		<div id="conversations" class="info">
 			<span class="label">Number of conversations:</span>
-			<span class="content">{{user.userConversations.length}}</span>
+			<span class="content">{{{user.userConversations.length}}}</span>
 		</div>
 		<div id="bio" class="info">
 			<span class="label">Bio:</span>
-			<span class="content">{{user.description}}</span>
+			<span class="content">{{{user.description}}}</span>
 		</div>
 		<div class="btn-fld">
 			<button id="edit-my-info" type="button">Edit</button>


### PR DESCRIPTION
This PR addresses issue #14 in which certain strings, such as the title of a conversation, show up to the user as escaped strings when viewed on the home or conversation pages.  For example, if the title of a question was entered as `<`, it would show up instead as `&lt;`

Other people seem to have encountered similar problems, and it looks like the solution is simple:
http://stackoverflow.com/questions/11450602/show-property-which-includes-html-tags

If we want to unescape the strings that we escaped before storage, we simply need to use three curly brackets instead of two on our Handlebars templates.