### PR TITLE
First pass at implementing archiving functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,6 +93,7 @@ app.post('/post/create', post.create);
 
 app.post('/user/delete', user.delete);
 app.post('/conversation/leave', conversation.leave);
+app.post('/conversaton/archive', conversation.archive);
 app.post('/conversation/delete', conversation.delete);
 app.post('/group/delete', group.delete);
 app.post('/post/delete', post.delete);

--- a/app.js
+++ b/app.js
@@ -93,7 +93,7 @@ app.post('/post/create', post.create);
 
 app.post('/user/delete', user.delete);
 app.post('/conversation/leave', conversation.leave);
-app.post('/conversaton/archive', conversation.archive);
+app.post('/conversation/archive', conversation.archive);
 app.post('/conversation/delete', conversation.delete);
 app.post('/group/delete', group.delete);
 app.post('/post/delete', post.delete);

--- a/public/js/Application.js
+++ b/public/js/Application.js
@@ -64,9 +64,35 @@ $('.choice-modal button[type=submit]').click(function (evt){
                         modal.style.display = 'none';
                         overlay.style.display = 'none';
                     }
-                });
+                }
+        );
     } else if (action === 'archive'){
-        // TODO(erik): Implement archiving functionality.
+        // Show placeholder waiting text.
+        $('.choice-modal .question').text('Archiving conversation...');
+
+        // Make the request to archive.
+        $.post(
+                '/conversation/archive',
+                {
+                    conversationId: conversationId, 
+                    _csrf: token
+                },
+                function (data){
+                    // Restore the text.
+                    $('.choice-modal .question').text(
+                            'Are you sure that you want to archive this conversation?');
+
+                    if (data.success){
+                        window.location.href = '/home';
+                    } else{
+                        alert('Sorry, an error occurred when archiving.  Try again in a bit.');
+
+                        // Remove the modal.
+                        modal.style.display = 'none';
+                        overlay.style.display = 'none';
+                    }
+                }
+        );
     } else{
         // Remove the modal.
         modal.style.display = 'none';

--- a/routes/conversation.js
+++ b/routes/conversation.js
@@ -267,8 +267,7 @@ exports.archive = function (req, res){
 	// id is found. 
 	User.findById( req.user._id, function (err, user){
 		if (err || !user){
-			resError(res, "Could not find the user.");
-			return;
+			return resError(res, "Could not find the user.");
 		}
 
 		// Save the id of the conversation that we want to archive.

--- a/routes/conversation.js
+++ b/routes/conversation.js
@@ -260,8 +260,7 @@ exports.leave = function (req, res){
  */
 exports.archive = function (req, res){
 	if (!req.user || !req.user._id){
-		resError(res, "Access denied.", "/error");
-		return;
+		return resError(res, "Access denied.", "/error");
 	}
 
 	// Search through the user's conversation list until the conversation with the correct
@@ -315,12 +314,12 @@ exports.archive = function (req, res){
 							res.send({success: true, redirect: '/home'});
 						});
 					} else{
-						reject(res, "Access denied.", "/error");
+						return resError(res, "Access denied.", "/error");
 					}
 				});
 			});
 		} else{
-			reject(res, "Access denied.", "/error");
+			return resError(res, "Access denied.", "/error");
 		}
 	});
 };

--- a/routes/conversation.js
+++ b/routes/conversation.js
@@ -265,7 +265,28 @@ exports.archive = function (req, res){
 	}
 
 	// Search through the user's conversation list until the conversation with the correct
-	// id is found. Modify the hallOfFame boolean associated with this conversation to be true.
+	// id is found. 
+	User.findById( req.user._id, function (err, user){
+		if (err){
+			reject(res, "Could not find the user.");
+			return;
+		}
+
+		// Save the id of the conversation that we want to archive.
+		var targetConversationId = JSON.stringify(req.body.conversationId);
+
+		// Find the index at which the target conversation exists amongst all of the user's conversations.
+		var conversationIds = user.userConversations.map(function(p) {return p.conversation});
+		var conversationIdStrings = conversationIds.map(function(id) {return JSON.stringify(id)});
+		var found = conversationIdStrings.indexOf(targetConversationId) !== -1;
+
+		// Modify the hallOfFame boolean associated with the conversation to true if it exists.
+		if (found) {
+			// Something along the lines of: user.userConversations[found].hallOfFame == true;
+		} else{
+			reject(res, "Access denied.", "/error");
+		}
+	});
 };
 
 exports.delete = function (req, res){

--- a/routes/conversation.js
+++ b/routes/conversation.js
@@ -255,6 +255,18 @@ exports.leave = function (req, res){
 	});
 };
 
+/**
+ * Action when a user archives a conversation.
+ */
+exports.archive = function (req, res){
+	if (!req.user || !req.user._id){
+		resError(res, "Access denied.", "/error");
+		return;
+	}
+
+	// Search through the user's conversation list until the conversation with the correct
+	// id is found. Modify the hallOfFame boolean associated with this conversation to be true.
+};
 
 exports.delete = function (req, res){
 	if (!req.user || !req.user._id){

--- a/routes/conversation.js
+++ b/routes/conversation.js
@@ -169,8 +169,6 @@ exports.leave = function (req, res){
 			var participantIds = convo.participants.map(function (p){return p._id});
 			var userString = JSON.stringify(req.user._id);
 			var participantIdStrings = participantIds.map(function (id){return JSON.stringify(id)});
-			// Should this 'found' variable definition be changed to the equivalent 'foundIndex' variable
-			// definitions used below in 'exports.archive'?
 			var found = participantIdStrings.indexOf(userString) !== -1;
 
 			if (found){
@@ -269,7 +267,7 @@ exports.archive = function (req, res){
 	// Search through the user's conversation list until the conversation with the correct
 	// id is found. 
 	User.findById( req.user._id, function (err, user){
-		if (err){
+		if (err || !user){
 			resError(res, "Could not find the user.");
 			return;
 		}
@@ -292,8 +290,8 @@ exports.archive = function (req, res){
 
 				// If there are no errors, proceed to update the isThrilled boolean of the user
 				// in the conversation object to true and save this object.
-				Conversation.findById(targetConversationId, function(err, convo){
-					if (err) return resError(res, "Could not find conversation");
+				Conversation.findById(req.body.conversationId, function(err, convo){
+					if (err || !convo) return resError(res, "Could not find conversation");
 
 					// Save the id of the user whose isThrilled boolean we want to set as true.
 					var userString = JSON.stringify(req.user._id);
@@ -320,6 +318,7 @@ exports.archive = function (req, res){
 						reject(res, "Access denied.", "/error");
 					}
 				});
+			});
 		} else{
 			reject(res, "Access denied.", "/error");
 		}


### PR DESCRIPTION
This PR looks at implementing 'archive conversation' functionality. The first commit sets up the front-end logic for archiving and links in a POST request to allow the front-end logic to trigger the back-end logic. The second commit is my first pass at filling out the back-end logic.

The back-end logic needs some more work for the functionality to be complete. @psybuzz would you mind taking a look and helping me out with this part in particular? I wrote the parts that I could in `exports.archive` of `routes/conversation.js` using `exports.leave` of the same file as an example, but I wasn't sure how to incorporate in promises as we do for leave functionality (or if that's even necessary here). Moreover, I included psuedo-code for how we would actually modify the hallOfFame boolean for the given conversation but wasn't sure how to actually modify the DB entry properly. Any comments you can provide here would be great!